### PR TITLE
Use gcc-13 to build Linux 6.16 on 24.04

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-linux (6.16.3-76061603.202508231538) noble; urgency=low
+linux (6.16.3-76061603.202508231538) questing; urgency=low
 
   [ Mainline Build ]
   Mainline build at commit: v6.16.3

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ XSC-Ubuntu-Compatible-Signing: ubuntu/4 pro/3
 Rules-Requires-Root: no
 Standards-Version: 3.9.4.0
 Build-Depends:
- gcc-14:native, gcc-14-aarch64-linux-gnu [arm64] <cross>, gcc-14-arm-linux-gnueabihf [armhf] <cross>, gcc-14-powerpc64le-linux-gnu [ppc64el] <cross>, gcc-14-riscv64-linux-gnu [riscv64] <cross>, gcc-14-s390x-linux-gnu [s390x] <cross>, gcc-14-x86-64-linux-gnu [amd64] <cross>,
+ gcc-13:native, gcc-13-aarch64-linux-gnu [arm64] <cross>, gcc-13-arm-linux-gnueabihf [armhf] <cross>, gcc-13-powerpc64le-linux-gnu [ppc64el] <cross>, gcc-13-riscv64-linux-gnu [riscv64] <cross>, gcc-13-s390x-linux-gnu [s390x] <cross>, gcc-13-x86-64-linux-gnu [amd64] <cross>,
  autoconf <!stage1>,
  automake <!stage1>,
  bc <!stage1>,
@@ -205,7 +205,7 @@ Architecture: all
 Multi-Arch: foreign
 Section: kernel
 Priority: optional
-Provides:
+Provides: 
  linux-cpupower,
 Recommends:
  bpftool (>= 7.6.0+6.14.0-8~),
@@ -721,3 +721,4 @@ Description: Linux kernel vision modules for version 6.16.3-76061603
  one of the linux-modules-vision-generic-64k* meta-packages,
  which will ensure that upgrades work correctly, and that supporting packages are
  also installed.
+

--- a/debian/rules.d/0-common-vars.mk
+++ b/debian/rules.d/0-common-vars.mk
@@ -1,4 +1,4 @@
-gcc:=gcc-14
+gcc:=gcc-13
 # Used when you need to 'escape' a comma.
 comma = ,
 empty :=


### PR DESCRIPTION
Update of #346. gcc-13 is installed by default, gcc-14 is not. Will merge by force push to avoid having to rebuild.