### PR TITLE
Revert "wifi: mt76: mt7925: add mutex protection in critical paths" (fixes #438 s2idle resume deadlock)

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mt7925/mac.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7925/mac.c
@@ -1337,11 +1337,9 @@ void mt7925_mac_reset_work(struct work_struct *work)
 	dev->hw_full_reset = false;
 	pm->suspended = false;
 	ieee80211_wake_queues(hw);
-	mt792x_mutex_acquire(dev);
 	ieee80211_iterate_active_interfaces(hw,
 					    IEEE80211_IFACE_ITER_RESUME_ALL,
 					    mt7925_vif_connect_iter, NULL);
-	mt792x_mutex_release(dev);
 	mt76_connac_power_save_sched(&dev->mt76.phy, pm);
 
 	mt7925_regd_change(&dev->phy, "00");

--- a/drivers/net/wireless/mediatek/mt76/mt7925/main.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7925/main.c
@@ -903,11 +903,9 @@ void mt7925_set_runtime_pm(struct mt792x_dev *dev)
 	bool monitor = !!(hw->conf.flags & IEEE80211_CONF_MONITOR);
 
 	pm->enable = pm->enable_user && !monitor;
-	mt792x_mutex_acquire(dev);
 	ieee80211_iterate_active_interfaces(hw,
 					    IEEE80211_IFACE_ITER_RESUME_ALL,
 					    mt7925_pm_interface_iter, dev);
-	mt792x_mutex_release(dev);
 	pm->ds_enable = pm->ds_enable_user && !monitor;
 	mt7925_mcu_set_deep_sleep(dev, pm->ds_enable);
 }
@@ -1499,12 +1497,14 @@ mt7925_mlo_pm_iter(void *priv, u8 *mac, struct ieee80211_vif *vif)
 	if (mvif->mlo_pm_state != MT792x_MLO_CHANGED_PS)
 		return;
 
+	mt792x_mutex_acquire(dev);
 	for_each_set_bit(i, &valid, IEEE80211_MLD_MAX_NUM_LINKS) {
 		bss_conf = mt792x_vif_to_bss_conf(vif, i);
 		if (!bss_conf)
 			continue;
 		mt7925_mcu_uni_bss_ps(dev, bss_conf);
 	}
+	mt792x_mutex_release(dev);
 }
 
 void mt7925_mlo_pm_work(struct work_struct *work)
@@ -1513,11 +1513,9 @@ void mt7925_mlo_pm_work(struct work_struct *work)
 					      mlo_pm_work.work);
 	struct ieee80211_hw *hw = mt76_hw(dev);
 
-	mt792x_mutex_acquire(dev);
 	ieee80211_iterate_active_interfaces(hw,
 					    IEEE80211_IFACE_ITER_RESUME_ALL,
 					    mt7925_mlo_pm_iter, dev);
-	mt792x_mutex_release(dev);
 }
 
 void mt7925_scan_work(struct work_struct *work)

--- a/drivers/net/wireless/mediatek/mt76/mt7925/pci.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7925/pci.c
@@ -582,12 +582,10 @@ static int _mt7925_pci_resume(struct device *device, bool restore)
 	}
 
 	/* restore previous ds setting */
-	mt792x_mutex_acquire(dev);
 	if (!pm->ds_enable)
 		mt7925_mcu_set_deep_sleep(dev, false);
 
 	mt7925_mcu_regd_update(dev, mdev->alpha2, dev->country_ie_env);
-	mt792x_mutex_release(dev);
 failed:
 	pm->suspended = false;
 


### PR DESCRIPTION
## Summary

Reverts commit a9971699b ("wifi: mt76: mt7925: add mutex protection in critical paths"), a Pop!_OS-only patch that introduces a 100% s2idle **resume deadlock** on machines with MediaTek mt7925 Wi-Fi. Fixes #438.

## Root cause

The commit wrapped the tail of `_mt7925_pci_resume()` in `mt792x_mutex`:

```c
mt792x_mutex_acquire(dev);
if (!pm->ds_enable)
    mt7925_mcu_set_deep_sleep(dev, false);
mt7925_mcu_regd_update(dev, mdev->alpha2, dev->country_ie_env);
mt792x_mutex_release(dev);
```

but `mt7925_mcu_regd_update()` and the deep-sleep path already acquire `mt792x_mutex` internally. `mt792x_mutex` is non-recursive, so the resume thread blocks forever on a lock it already holds. The system suspends but never wakes — the journal ends at `PM: suspend entry (s2idle)` and a forced power-off is the only recovery.

- The reverted commit is **not present upstream**; reverting it has no upstream impact.
- Its message also claims pci.c wraps `ieee80211_iterate_active_interfaces()`, which does not match the actual diff.

## Impact

Reproduced on kernels 7.0.9 / 7.0.11 (`master_noble`) across MSI Stealth A16, Framework 13/16/Desktop, Lenovo ThinkPad T14/P14, ASUS ProArt P16 and Dell Alienware — any hardware with mt7925. 6.18.7 is unaffected.

## Validation

Root cause isolated by bisect in #438 (thanks @DJWightman): a clean `master_noble` with only this commit reverted resumes correctly. The revert re-applies cleanly against current `master_noble`.
