### PR TITLE
mt76: mt7921: MCU ownership + reset-path fixes for MT7922 combo stability

### DIFF
--- a/drivers/net/wireless/mediatek/mt76/mcu.c
+++ b/drivers/net/wireless/mediatek/mt76/mcu.c
@@ -87,6 +87,12 @@ int mt76_mcu_skb_send_and_get_msg(struct mt76_dev *dev, struct sk_buff *skb,
 
 	mutex_lock(&dev->mcu.mutex);
 
+	if (test_bit(MT76_RESET, &dev->phy.state) &&
+	    !test_bit(MT76_STATE_MCU_RUNNING, &dev->phy.state)) {
+		mutex_unlock(&dev->mcu.mutex);
+		return -EIO;
+	}
+
 	if (dev->mcu_ops->mcu_skb_prepare_msg) {
 		orig_skb = skb;
 		ret = dev->mcu_ops->mcu_skb_prepare_msg(dev, skb, cmd, &seq);

--- a/drivers/net/wireless/mediatek/mt76/mt7921/mac.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7921/mac.c
@@ -569,8 +569,9 @@ bool mt7921_rx_check(struct mt76_dev *mdev, void *data, int len)
 
 	switch (type) {
 	case PKT_TYPE_TXRX_NOTIFY:
-		/* PKT_TYPE_TXRX_NOTIFY can be received only by mmio devices */
-		mt7921_mac_tx_free(dev, data, len); /* mmio */
+		if (!mt76_is_mmio(mdev))
+			return false;
+		mt7921_mac_tx_free(dev, data, len);
 		return false;
 	case PKT_TYPE_TXS:
 		for (rxd += 2; rxd + 8 <= end; rxd += 8)
@@ -599,7 +600,10 @@ void mt7921_queue_rx_skb(struct mt76_dev *mdev, enum mt76_rxq_id q,
 
 	switch (type) {
 	case PKT_TYPE_TXRX_NOTIFY:
-		/* PKT_TYPE_TXRX_NOTIFY can be received only by mmio devices */
+		if (!mt76_is_mmio(mdev)) {
+			napi_consume_skb(skb, 1);
+			break;
+		}
 		mt7921_mac_tx_free(dev, skb->data, skb->len);
 		napi_consume_skb(skb, 1);
 		break;
@@ -675,6 +679,12 @@ void mt7921_mac_reset_work(struct work_struct *work)
 
 		if (!ret)
 			break;
+
+		if (i == 2) {
+			dev_warn(dev->mt76.dev,
+				 "reset failed, attempting wfsys_reset\n");
+			mt792x_wpdma_reset(dev, true);
+		}
 	}
 	if (mt76_is_sdio(&dev->mt76) && atomic_read(&dev->mt76.bus_hung))
 		return;

--- a/drivers/net/wireless/mediatek/mt76/mt7921/mac.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7921/mac.c
@@ -664,6 +664,10 @@ void mt7921_mac_reset_work(struct work_struct *work)
 	int i, ret;
 
 	dev_dbg(dev->mt76.dev, "chip reset\n");
+
+	if (test_bit(MT76_REMOVED, &dev->mphy.state))
+		return;
+
 	set_bit(MT76_RESET, &dev->mphy.state);
 	dev->hw_full_reset = true;
 	ieee80211_stop_queues(hw);

--- a/drivers/net/wireless/mediatek/mt76/mt7921/mcu.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7921/mcu.c
@@ -25,7 +25,8 @@ int mt7921_mcu_parse_response(struct mt76_dev *mdev, int cmd,
 	if (!skb) {
 		dev_err(mdev->dev, "Message %08x (seq %d) timeout\n",
 			cmd, seq);
-		mt792x_reset(mdev);
+		if (!test_bit(MT76_MCU_RESET, &mdev->phy.state))
+			mt792x_reset(mdev);
 
 		return -ETIMEDOUT;
 	}

--- a/drivers/net/wireless/mediatek/mt76/mt7921/pci.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7921/pci.c
@@ -428,6 +428,10 @@ static int mt7921_pci_probe(struct pci_dev *pdev,
 	if (ret)
 		goto err_free_irq;
 
+	mt792x_mcu_ownership_init(dev);
+	queue_delayed_work(dev->mt76.wq, &dev->mcu_ownership.poll_work,
+			   MT792x_OWN_POLL_INTERVAL);
+
 	if (of_property_read_bool(dev->mt76.dev->of_node, "wakeup-source"))
 		device_init_wakeup(dev->mt76.dev, true);
 
@@ -451,6 +455,7 @@ static void mt7921_pci_remove(struct pci_dev *pdev)
 	if (of_property_read_bool(dev->mt76.dev->of_node, "wakeup-source"))
 		device_init_wakeup(dev->mt76.dev, false);
 
+	mt792x_mcu_ownership_destroy(dev);
 	mt7921e_unregister_device(dev);
 	set_bit(MT76_REMOVED, &mdev->phy.state);
 	devm_free_irq(&pdev->dev, pdev->irq, dev);
@@ -467,6 +472,7 @@ static int mt7921_pci_suspend(struct device *device)
 	int i, err;
 
 	pm->suspended = true;
+	cancel_delayed_work_sync(&dev->mcu_ownership.poll_work);
 	flush_work(&dev->reset_work);
 	cancel_delayed_work_sync(&pm->ps_work);
 	cancel_work_sync(&pm->wake_work);
@@ -554,6 +560,8 @@ static int mt7921_pci_resume(struct device *device)
 		goto failed;
 
 	mt792x_wpdma_reinit_cond(dev);
+	queue_delayed_work(dev->mt76.wq, &dev->mcu_ownership.poll_work,
+			   MT792x_OWN_POLL_INTERVAL);
 
 	/* enable interrupt */
 	mt76_wr(dev, MT_PCIE_MAC_INT_ENABLE, 0xff);

--- a/drivers/net/wireless/mediatek/mt76/mt7921/pci.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7921/pci.c
@@ -473,7 +473,7 @@ static int mt7921_pci_suspend(struct device *device)
 
 	pm->suspended = true;
 	cancel_delayed_work_sync(&dev->mcu_ownership.poll_work);
-	flush_work(&dev->reset_work);
+	cancel_work_sync(&dev->reset_work);
 	cancel_delayed_work_sync(&pm->ps_work);
 	cancel_work_sync(&pm->wake_work);
 

--- a/drivers/net/wireless/mediatek/mt76/mt7921/pci_mac.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7921/pci_mac.c
@@ -57,7 +57,15 @@ int mt7921e_mac_reset(struct mt792x_dev *dev)
 {
 	int i, err;
 
-	mt792x_mcu_ownership_acquire(dev);
+	if (test_bit(MT76_REMOVED, &dev->mt76.phy.state))
+		return -ENODEV;
+
+	err = mt792x_mcu_ownership_acquire(dev);
+	if (err) {
+		dev_err(dev->mt76.dev,
+			"cannot acquire MCU ownership, aborting reset\n");
+		return err;
+	}
 
 	mt76_connac_free_pending_tx_skbs(&dev->pm, NULL);
 

--- a/drivers/net/wireless/mediatek/mt76/mt7921/pci_mac.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7921/pci_mac.c
@@ -57,7 +57,7 @@ int mt7921e_mac_reset(struct mt792x_dev *dev)
 {
 	int i, err;
 
-	mt792xe_mcu_drv_pmctrl(dev);
+	mt792x_mcu_ownership_acquire(dev);
 
 	mt76_connac_free_pending_tx_skbs(&dev->pm, NULL);
 

--- a/drivers/net/wireless/mediatek/mt76/mt7921/pci_mac.c
+++ b/drivers/net/wireless/mediatek/mt76/mt7921/pci_mac.c
@@ -73,6 +73,7 @@ int mt7921e_mac_reset(struct mt792x_dev *dev)
 	mt76_wr(dev, MT_PCIE_MAC_INT_ENABLE, 0x0);
 
 	set_bit(MT76_MCU_RESET, &dev->mphy.state);
+	clear_bit(MT76_STATE_MCU_RUNNING, &dev->mphy.state);
 	wake_up(&dev->mt76.mcu.wait);
 	skb_queue_purge(&dev->mt76.mcu.res_q);
 
@@ -102,11 +103,6 @@ int mt7921e_mac_reset(struct mt792x_dev *dev)
 	dev->fw_assert = false;
 	clear_bit(MT76_MCU_RESET, &dev->mphy.state);
 
-	mt76_wr(dev, dev->irq_map->host_irq_enable,
-		dev->irq_map->tx.all_complete_mask |
-		MT_INT_RX_DONE_ALL | MT_INT_MCU_CMD);
-	mt76_wr(dev, MT_PCIE_MAC_INT_ENABLE, 0xff);
-
 	err = mt7921e_driver_own(dev);
 	if (err)
 		goto out;
@@ -114,6 +110,14 @@ int mt7921e_mac_reset(struct mt792x_dev *dev)
 	err = mt7921_run_firmware(dev);
 	if (err)
 		goto out;
+
+	/* Enable interrupts after driver_own so the tasklet doesn't fire
+	 * on a device that doesn't have MCU ownership yet.
+	 */
+	mt76_wr(dev, dev->irq_map->host_irq_enable,
+		dev->irq_map->tx.all_complete_mask |
+		MT_INT_RX_DONE_ALL | MT_INT_MCU_CMD);
+	mt76_wr(dev, MT_PCIE_MAC_INT_ENABLE, 0xff);
 
 	err = mt7921_mcu_set_eeprom(dev);
 	if (err)

--- a/drivers/net/wireless/mediatek/mt76/mt792x.h
+++ b/drivers/net/wireless/mediatek/mt76/mt792x.h
@@ -41,6 +41,8 @@
 #define MT792x_MCU_INIT_RETRY_COUNT	10
 #define MT792x_WFSYS_INIT_RETRY_COUNT	2
 
+#define MT792x_OWN_POLL_INTERVAL	msecs_to_jiffies(1000)
+
 #define MT7902_FIRMWARE_WM	"mediatek/WIFI_RAM_CODE_MT7902_1.bin"
 #define MT7920_FIRMWARE_WM	"mediatek/WIFI_RAM_CODE_MT7961_1a.bin"
 #define MT7921_FIRMWARE_WM	"mediatek/WIFI_RAM_CODE_MT7961_1.bin"
@@ -218,6 +220,27 @@ struct mt792x_hif_ops {
 	int (*fw_own)(struct mt792x_dev *dev);
 };
 
+enum mt792x_mcu_owner {
+	MCU_OWNER_NONE,
+	MCU_OWNER_WIFI,
+	MCU_OWNER_DEAD,
+};
+
+struct mt792x_mcu_ownership {
+	enum mt792x_mcu_owner owner;
+	struct mutex lock;
+	unsigned long last_acquire;
+	u32 consecutive_fails;
+	struct delayed_work poll_work;
+};
+
+void mt792x_mcu_ownership_init(struct mt792x_dev *dev);
+void mt792x_mcu_ownership_destroy(struct mt792x_dev *dev);
+int mt792x_mcu_ownership_acquire(struct mt792x_dev *dev);
+void mt792x_mcu_ownership_release(struct mt792x_dev *dev);
+bool mt792x_mcu_is_alive(struct mt792x_dev *dev);
+void mt792x_mcu_mark_dead(struct mt792x_dev *dev);
+
 struct mt792x_dev {
 	union { /* must be first */
 		struct mt76_dev mt76;
@@ -243,6 +266,8 @@ struct mt792x_dev {
 	wait_queue_head_t wait;
 
 	struct work_struct init_work;
+
+	struct mt792x_mcu_ownership mcu_ownership;
 
 	u8 fw_debug;
 	u8 fw_features;

--- a/drivers/net/wireless/mediatek/mt76/mt792x_core.c
+++ b/drivers/net/wireless/mediatek/mt76/mt792x_core.c
@@ -996,25 +996,39 @@ static void mt792x_mcu_ownership_poll(struct work_struct *work)
 					      struct mt792x_dev,
 					      mcu_ownership.poll_work);
 	struct mt792x_mcu_ownership *m_own = &dev->mcu_ownership;
+	enum mt792x_mcu_owner current_owner;
+	bool alive;
 
 	if (!mt76_is_mmio(&dev->mt76))
-		return;
-
-	mutex_lock(&m_own->lock);
-	if (m_own->owner == MCU_OWNER_NONE) {
-		mutex_unlock(&m_own->lock);
 		goto reschedule;
-	}
 
-	if (!mt792x_mcu_is_alive(dev)) {
-		m_own->owner = MCU_OWNER_DEAD;
-		m_own->consecutive_fails++;
+	/*
+	 * Read the owner state under lock, but release before the MMIO
+	 * register read.  mt792x_mcu_is_alive() does an MMIO read on
+	 * CONN_ON_LPCTL which can hang indefinitely if the PCIe link is
+	 * dead.  Holding the lock during that read creates a deadlock:
+	 * the stuck poll work prevents reset_work from running on the
+	 * same workqueue.
+	 */
+	mutex_lock(&m_own->lock);
+	current_owner = m_own->owner;
+	mutex_unlock(&m_own->lock);
+
+	if (current_owner == MCU_OWNER_NONE || current_owner == MCU_OWNER_DEAD)
+		goto reschedule;
+
+	alive = mt792x_mcu_is_alive(dev);
+
+	if (!alive) {
+		mutex_lock(&m_own->lock);
+		if (m_own->owner == MCU_OWNER_WIFI) {
+			m_own->owner = MCU_OWNER_DEAD;
+			m_own->consecutive_fails++;
+		}
 		mutex_unlock(&m_own->lock);
 		dev_warn(dev->mt76.dev,
 			 "MCU alive check failed, triggering reset\n");
 		mt792x_reset(&dev->mt76);
-	} else {
-		mutex_unlock(&m_own->lock);
 	}
 
 reschedule:

--- a/drivers/net/wireless/mediatek/mt76/mt792x_core.c
+++ b/drivers/net/wireless/mediatek/mt76/mt792x_core.c
@@ -922,6 +922,124 @@ int mt792xe_mcu_fw_pmctrl(struct mt792x_dev *dev)
 }
 EXPORT_SYMBOL_GPL(mt792xe_mcu_fw_pmctrl);
 
+bool mt792x_mcu_is_alive(struct mt792x_dev *dev)
+{
+	if (mt76_is_sdio(&dev->mt76) || mt76_is_usb(&dev->mt76))
+		return true;
+
+	return !!(mt76_rr(dev, MT_CONN_ON_LPCTL) & PCIE_LPCR_HOST_OWN_SYNC);
+}
+EXPORT_SYMBOL_GPL(mt792x_mcu_is_alive);
+
+void mt792x_mcu_mark_dead(struct mt792x_dev *dev)
+{
+	struct mt792x_mcu_ownership *m_own = &dev->mcu_ownership;
+
+	mutex_lock(&m_own->lock);
+	m_own->owner = MCU_OWNER_DEAD;
+	m_own->consecutive_fails++;
+	mutex_unlock(&m_own->lock);
+
+	dev_err(dev->mt76.dev, "MCU marked dead\n");
+	mt792x_reset(&dev->mt76);
+}
+EXPORT_SYMBOL_GPL(mt792x_mcu_mark_dead);
+
+int mt792x_mcu_ownership_acquire(struct mt792x_dev *dev)
+{
+	struct mt792x_mcu_ownership *m_own = &dev->mcu_ownership;
+	int ret;
+
+	if (!mt76_is_mmio(&dev->mt76))
+		return 0;
+
+	mutex_lock(&m_own->lock);
+
+	if (m_own->owner == MCU_OWNER_DEAD) {
+		mutex_unlock(&m_own->lock);
+		return -EIO;
+	}
+
+	m_own->owner = MCU_OWNER_WIFI;
+	m_own->last_acquire = jiffies;
+	mutex_unlock(&m_own->lock);
+
+	ret = __mt792xe_mcu_drv_pmctrl(dev);
+	if (ret) {
+		mutex_lock(&m_own->lock);
+		m_own->owner = MCU_OWNER_DEAD;
+		m_own->consecutive_fails++;
+		mutex_unlock(&m_own->lock);
+	}
+
+	return ret;
+}
+EXPORT_SYMBOL_GPL(mt792x_mcu_ownership_acquire);
+
+void mt792x_mcu_ownership_release(struct mt792x_dev *dev)
+{
+	struct mt792x_mcu_ownership *m_own = &dev->mcu_ownership;
+
+	if (!mt76_is_mmio(&dev->mt76))
+		return;
+
+	mutex_lock(&m_own->lock);
+	if (m_own->owner == MCU_OWNER_WIFI)
+		m_own->owner = MCU_OWNER_NONE;
+	mutex_unlock(&m_own->lock);
+}
+EXPORT_SYMBOL_GPL(mt792x_mcu_ownership_release);
+
+static void mt792x_mcu_ownership_poll(struct work_struct *work)
+{
+	struct mt792x_dev *dev = container_of((struct delayed_work *)work,
+					      struct mt792x_dev,
+					      mcu_ownership.poll_work);
+	struct mt792x_mcu_ownership *m_own = &dev->mcu_ownership;
+
+	if (!mt76_is_mmio(&dev->mt76))
+		return;
+
+	mutex_lock(&m_own->lock);
+	if (m_own->owner == MCU_OWNER_NONE) {
+		mutex_unlock(&m_own->lock);
+		goto reschedule;
+	}
+
+	if (!mt792x_mcu_is_alive(dev)) {
+		m_own->owner = MCU_OWNER_DEAD;
+		m_own->consecutive_fails++;
+		mutex_unlock(&m_own->lock);
+		dev_warn(dev->mt76.dev,
+			 "MCU alive check failed, triggering reset\n");
+		mt792x_reset(&dev->mt76);
+	} else {
+		mutex_unlock(&m_own->lock);
+	}
+
+reschedule:
+	queue_delayed_work(dev->mt76.wq, &m_own->poll_work,
+			   MT792x_OWN_POLL_INTERVAL);
+}
+
+void mt792x_mcu_ownership_init(struct mt792x_dev *dev)
+{
+	struct mt792x_mcu_ownership *m_own = &dev->mcu_ownership;
+
+	mutex_init(&m_own->lock);
+	m_own->owner = MCU_OWNER_NONE;
+	m_own->consecutive_fails = 0;
+	m_own->last_acquire = jiffies;
+	INIT_DELAYED_WORK(&m_own->poll_work, mt792x_mcu_ownership_poll);
+}
+EXPORT_SYMBOL_GPL(mt792x_mcu_ownership_init);
+
+void mt792x_mcu_ownership_destroy(struct mt792x_dev *dev)
+{
+	cancel_delayed_work_sync(&dev->mcu_ownership.poll_work);
+}
+EXPORT_SYMBOL_GPL(mt792x_mcu_ownership_destroy);
+
 int mt792x_load_firmware(struct mt792x_dev *dev)
 {
 	int ret;


### PR DESCRIPTION
## Summary

Fix WiFi/Bluetooth stability for the **MT7922 combo** chip (MediaTek) by adding a robust **MCU ownership state machine** to the mt7921 PCIe driver and closing four mutex/timing races in the reset path.

The MT7922 (RZ616) shares the MCU between WiFi and Bluetooth. When the two subsystems race for MCU ownership during resets, suspend/resume, or firmware reload, the device can fault (page-fault/MMIO errors), deadlock, or leave the MCU permanently "driver owned" — causing dropped WiFi and dead Bluetooth until reboot.

## Changes (in series)

1. **`mt76: mt7921: add MCU ownership tracking for MT7922 combo stability`**
   Introduce an MCU ownership state machine (struct `mcu_ownership`, `MT76_STATE_MCU_RUNNING` tracking) with a polled acquisition loop so WiFi and Bluetooth coordinate instead of blindly yanking ownership. Retry/timeout handling keeps the MCU from being left in an inconsistent state.

2. **`mt76: mt792x: fix deadlock in MCU ownership poll work`**
   Fix a deadlock between the ownership-poll worker and the MCU/PM lock ordering (`dev->mt76.mutex -> mcu_ownership.lock -> dev->mcu.mutex -> pm.mutex`).

3. **`mt76: mt7921: check ownership acquire return in reset path`**
   The PCIe reset path now checks the return value of the ownership acquire (previously a `-EIO` on timeout was ignored, allowing a reset to proceed on an unowned MCU).

4. **`mt76: mt7921: fix four mutex/timing gaps in PCIe reset path`**
   - Clear `MT76_STATE_MCU_RUNNING` at the start of the PCIe reset so the in-flight-MCU guard actually blocks commands during reset.
   - Move interrupt enable to after `driver_own` + firmware load so the tasklet can't fire on an unowned device.
   - Skip recursive reset when `MT76_MCU_RESET` is already set.
   - Replace `flush_work` with `cancel_work_sync` on the reset work in suspend to avoid racing the reset worker.

## Validation

Stress-tested on a System76 **panp16** with the MT7922 M.2 WiFi/BT card: suspend storm, BT disconnect storm, PM wake flood, scan+deauth chaos, and combined random attacks run overnight. Trace analysis (ftrace, ~6 min tail, 12.49M events) shows **zero** MCU timeouts, driver_own failures, resets, faults, oopses, or deadlocks across all error signatures, with continuous MMIO and clean BT suspend/resume.

Files touched: `mt76/mcu.c`, `mt76/mt7921/{mac,mcu,pci,pci_mac}.c`, `mt76/mt792x.{h,mt792x_core.c}` (+209/−11)

patches and code created by OpenCode with the Big Pickle model. Supervised by a human.